### PR TITLE
Add v0.1 summary information

### DIFF
--- a/nb/5.post_analysis/v0.1-overview.ipynb
+++ b/nb/5.post_analysis/v0.1-overview.ipynb
@@ -1,0 +1,219 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "import sqlalchemy\n",
+    "import tqdm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load MySQL password from file\n",
+    "with open('../../mysql_password.txt') as f:\n",
+    "    password = f.readline().strip()\n",
+    "    \n",
+    "engine = sqlalchemy.create_engine(f\"mysql+mysqlconnector://mnz2108:{password}@localhost/effect_nsides\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "| Number of | Value |\n",
+    "| ----------- | ----- |\n",
+    "| Drugs ($\\geq$ 1 exposure) | 3,394 |\n",
+    "| Adverse events types ($\\geq$ 1 occurrence) | 17,552 |\n",
+    "| Drug-event pairs | 9,505,200 |\n",
+    "| Significant* drug-event pairs | 125,647 |\n",
+    "| Drug-drug-event triplets | 222,155,888 |\n",
+    "| Significant* drug-drug-event triplets† | 5,729,992 |\n",
+    "\n",
+    "\n",
+    "\\* Significant determined by `LOG(PRR) - 1.96 * PRR_error > LOG(2)`\n",
+    "\n",
+    "† This is not filtered by OFFSIDES, meaning a drug-drug-event triplet can be significant even if one of the drugs is more significantly associated with the event by itself."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(3394,)]"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Number of drugs\n",
+    "query = \"\"\"\n",
+    "SELECT COUNT(DISTINCT drug_concept_id) FROM DRUG_EXPOSURE;\n",
+    "\"\"\"\n",
+    "engine.execute(query).fetchall()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(17552,)]"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Number of conditions\n",
+    "query = \"\"\"\n",
+    "SELECT COUNT(DISTINCT condition_concept_id) FROM CONDITION_OCCURRENCE;\n",
+    "\"\"\"\n",
+    "engine.execute(query).fetchall()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(9505200,)]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Number of drug-condition pairs\n",
+    "query = \"\"\"\n",
+    "SELECT COUNT(DISTINCT drug_concept_id,condition_concept_id)\n",
+    "FROM OFFSIDES;\n",
+    "\"\"\"\n",
+    "engine.execute(query).fetchall()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(125647,)]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Number of significant drug-condition pairs\n",
+    "query = \"\"\"\n",
+    "SELECT COUNT(*)\n",
+    "FROM OFFSIDES\n",
+    "WHERE LOG(PRR) - 1.96 * PRR_error > LOG(2);\n",
+    "\"\"\"\n",
+    "engine.execute(query).fetchall()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(222155888,)]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Number of drug-drug-condition triplets\n",
+    "query = \"\"\"\n",
+    "SELECT COUNT(DISTINCT drug_concept_id_1,drug_concept_id_2,condition_concept_id)\n",
+    "FROM TWOSIDES;\n",
+    "\"\"\"\n",
+    "engine.execute(query).fetchall()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(5729992,)]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Number of significant drug-drug-condition triplets\n",
+    "query = \"\"\"\n",
+    "SELECT COUNT(*)\n",
+    "FROM TWOSIDES\n",
+    "WHERE LOG(PRR) - 1.96 * PRR_error > LOG(2);\n",
+    "\"\"\"\n",
+    "engine.execute(query).fetchall()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:nsides] *",
+   "language": "python",
+   "name": "conda-env-nsides-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/nb/5.post_analysis/v0.1-overview.ipynb
+++ b/nb/5.post_analysis/v0.1-overview.ipynb
@@ -8,8 +8,7 @@
    "source": [
     "import pandas as pd\n",
     "\n",
-    "import sqlalchemy\n",
-    "import tqdm"
+    "import sqlalchemy"
    ]
   },
   {

--- a/release-notes/v0.1.md
+++ b/release-notes/v0.1.md
@@ -6,6 +6,23 @@ We are releasing source code (notebooks and scripts) on [GitHub](https://github.
 
 <a name="1">[1]</a> Tatonetti, Nicholas P., P. Ye Patrick, Roxana Daneshjou, and Russ B. Altman. "Data-driven prediction of drug effects and interactions." Science translational medicine 4, no. 125 (2012): 125ra31-125ra31. [doi:10.1126/scitranslmed.3003377](https://doi.org/10.1126/scitranslmed.3003377)
 
+## Summary information
+
+| Number of | Value |
+| ----------- | ----- |
+| Drugs (≥ 1 exposure) | 3,394 |
+| Adverse events types (≥ 1 occurrence) | 17,552 |
+| Drug-event pairs | 9,505,200 |
+| Significant[*](#asterisk0) drug-event pairs | 125,647 |
+| Drug-drug-event triplets[†](#dagger0) | 222,155,888 |
+| Significant[*](#asterisk0) drug-drug-event triplets[†](#dagger0) | 5,729,992 |
+
+
+<a name="asterisk0">\*</a> Significant determined by `LOG(PRR) - 1.96 * PRR_error > LOG(2)`
+
+<a name="dagger0">†</a> This is not filtered by OFFSIDES, meaning a drug-drug-event triplet can be significant even if one of the drugs is more significantly associated with the event by itself.
+
+
 ## Notes on methods used to compute data
 
 ### <a name="signal-detection-methods">Signal detection methods</a>


### PR DESCRIPTION
Adds a notebook for computing release summary information and adds summary to the release notes.

| Number of | Value |
| ----------- | ----- |
| Drugs (≥ 1 exposure) | 3,394 |
| Adverse events types (≥ 1 occurrence) | 17,552 |
| Drug-event pairs | 9,505,200 |
| Significant[*](#asterisk0) drug-event pairs | 125,647 |
| Drug-drug-event triplets[†](#dagger0) | 222,155,888 |
| Significant[*](#asterisk0) drug-drug-event triplets[†](#dagger0) | 5,729,992 |


<a name="asterisk0">\*</a> Significant determined by `LOG(PRR) - 1.96 * PRR_error > LOG(2)`

<a name="dagger0">†</a> This is not filtered by OFFSIDES, meaning a drug-drug-event triplet can be significant even if one of the drugs is more significantly associated with the event by itself.
